### PR TITLE
Ensure minimum viewport dimensions for gravity section

### DIFF
--- a/css/page.css
+++ b/css/page.css
@@ -180,6 +180,8 @@ html{
   padding: 4em 2em;
   position: relative;
   overflow: hidden;
+  min-height: 100vh;
+  min-width: 100vw;
 }
 
 .gravity-wrapper {


### PR DESCRIPTION
Added min-height: 100vh and min-width: 100vw to .projects section
to prevent gravity background from rendering too small on initial load