### PR TITLE
Delay gravity iframe loading to prevent incorrect canvas dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
     </section>
     <section class="projects">
       <div class="gravity-wrapper">
-        <iframe class="gravity-bg" src="./subpages/van/gravity/build/index.html" frameborder="0"></iframe>
+        <iframe class="gravity-bg" data-src="./subpages/van/gravity/build/index.html" frameborder="0"></iframe>
       </div>
       <div class="gravity-fill"></div>
       <div class="gravity-overlay" id="gravity-overlay">

--- a/scripts/page.js
+++ b/scripts/page.js
@@ -403,3 +403,10 @@ if (gravityResetBtn && gravityIframe) {
     gravityIframe.src = gravityIframe.src;
   });
 }
+
+// Delay loading gravity iframe to ensure proper dimensions
+setTimeout(() => {
+  if (gravityIframe && gravityIframe.dataset.src) {
+    gravityIframe.src = gravityIframe.dataset.src;
+  }
+}, 4000);


### PR DESCRIPTION
Changed iframe src to data-src and added 4-second delay before loading to ensure .gravity-wrapper has proper dimensions before canvas renders. This prevents the default 300x150 canvas size on initial load.