### PR TITLE
Fix padding and improve mobile drawing interaction

### DIFF
--- a/css/page.css
+++ b/css/page.css
@@ -177,7 +177,7 @@ html{
 /* Projects Section */
 .projects {
   background-color: var(--dark-purple);
-  padding: 4em 2em 4em 0;
+  padding: 4em 0;
   position: relative;
   overflow: hidden;
   min-height: 100vh;


### PR DESCRIPTION
- Remove right padding from projects section (now 4em top/bottom, 0 left/right)
- Add touch event handlers for mobile devices to draw cells with line algorithm
- Lock page scrolling when in edit mode on mobile
- Allow scrolling while drawing when not in edit mode